### PR TITLE
ImageViewer::updateTitle: show mouse coordinate in normalized form as well

### DIFF
--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -2010,7 +2010,7 @@ void ImageViewer::updateTitle() {
         }
 
         caption += fmt::format(
-            " – @{},{} / {}x{}: {}", imageCoords.x(), imageCoords.y(), mCurrentImage->size().x(), mCurrentImage->size().y(), valuesString
+            " – @{},{} ({:.3f},{:.3f}) / {}x{}: {}", imageCoords.x(), imageCoords.y(), imageCoords.x() / (double)mCurrentImage->size().x(), imageCoords.y() / (double)mCurrentImage->size().y(), mCurrentImage->size().x(), mCurrentImage->size().y(), valuesString
         );
     }
 


### PR DESCRIPTION
This would be useful when one wants to specify a location on an image independent of the image resolution.